### PR TITLE
Refactor HeroSection component to use a div wrapper for Image component

### DIFF
--- a/src/components/home/HeroSection.tsx
+++ b/src/components/home/HeroSection.tsx
@@ -9,15 +9,17 @@ const HeroSection = () => {
 				<div className="relative flex justify-center lg:order-last">
 					<div className="absolute -top-16 -right-2 w-64 h-64 bg-teal-500 rounded-full mix-blend-multiply filter blur-2xl opacity-60 animate-blob sm:w-80 sm:h-80"></div>
 					<div className="absolute top-16 -left-2 w-64 h-64 bg-baseColor rounded-full mix-blend-multiply filter blur-2xl opacity-60 animation-delay-2000 animate-blob sm:w-80 sm:h-80"></div>
-					<Image
-						src="https://res.cloudinary.com/degyjrpjj/image/upload/v1688584020/galsendev/main/tce1ijjs4dxm8vl8qxls.png"
-						width="800"
-						height="800"
-						alt="Landing Illustration"
-						loading="eager"
-						priority={true}
-						className="object-cover w-auto h-auto"
-					/>
+					<div className="w-full h-full max-w-xl">
+						<Image
+							src="https://res.cloudinary.com/degyjrpjj/image/upload/v1688584020/galsendev/main/tce1ijjs4dxm8vl8qxls.png"
+							width="800"
+							height="800"
+							alt="Landing Illustration"
+							loading="eager"
+							priority={true}
+							className="object-cover"
+						/>
+					</div>
 				</div>
 				<div className="mt-12 mx-auto max-w-lg lg:m-0 lg:max-w-md">
 					<h2 className="text-xl font-bold sm:text-2xl text-transparent">


### PR DESCRIPTION
This Pull Request addresses the issue [#81](https://github.com/GalsenDev221/website/issues/81) where the hero image appears too small on some devices. The proposed solution is to refactor the HeroSection component to use a div wrapper for the Image component. 

### Testing:
Tested on Firefox, Chrome, Microsoft Edge, and Brave browsers.


### Changes:
Refactored the HeroSection component to use a div wrapper for the Image component to address the sizing issue with the hero image.

Please review and provide feedback. Thank you!