### PR TITLE
[build(deps): bump next from 14.1.1 to 14.2.12]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
 				"@types/react-dom": "18.0.10",
 				"clsx": "^2.0.0",
 				"module-name": "^0.0.1-security",
-				"next": "14.1.1",
+				"next": "14.2.12",
 				"next-translate": "^1.6.0",
 				"react": "18.2.0",
 				"react-dom": "18.2.0",
@@ -706,9 +706,9 @@
 			}
 		},
 		"node_modules/@next/env": {
-			"version": "14.1.1",
-			"resolved": "https://registry.npmjs.org/@next/env/-/env-14.1.1.tgz",
-			"integrity": "sha512-7CnQyD5G8shHxQIIg3c7/pSeYFeMhsNbpU/bmvH7ZnDql7mNRgg8O2JZrhrc/soFnfBnKP4/xXNiiSIPn2w8gA=="
+			"version": "14.2.12",
+			"resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.12.tgz",
+			"integrity": "sha512-3fP29GIetdwVIfIRyLKM7KrvJaqepv+6pVodEbx0P5CaMLYBtx+7eEg8JYO5L9sveJO87z9eCReceZLi0hxO1Q=="
 		},
 		"node_modules/@next/eslint-plugin-next": {
 			"version": "13.2.4",
@@ -720,9 +720,9 @@
 			}
 		},
 		"node_modules/@next/swc-darwin-arm64": {
-			"version": "14.1.1",
-			"resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.1.1.tgz",
-			"integrity": "sha512-yDjSFKQKTIjyT7cFv+DqQfW5jsD+tVxXTckSe1KIouKk75t1qZmj/mV3wzdmFb0XHVGtyRjDMulfVG8uCKemOQ==",
+			"version": "14.2.12",
+			"resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.12.tgz",
+			"integrity": "sha512-crHJ9UoinXeFbHYNok6VZqjKnd8rTd7K3Z2zpyzF1ch7vVNKmhjv/V7EHxep3ILoN8JB9AdRn/EtVVyG9AkCXw==",
 			"cpu": [
 				"arm64"
 			],
@@ -735,9 +735,9 @@
 			}
 		},
 		"node_modules/@next/swc-darwin-x64": {
-			"version": "14.1.1",
-			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.1.1.tgz",
-			"integrity": "sha512-KCQmBL0CmFmN8D64FHIZVD9I4ugQsDBBEJKiblXGgwn7wBCSe8N4Dx47sdzl4JAg39IkSN5NNrr8AniXLMb3aw==",
+			"version": "14.2.12",
+			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.12.tgz",
+			"integrity": "sha512-JbEaGbWq18BuNBO+lCtKfxl563Uw9oy2TodnN2ioX00u7V1uzrsSUcg3Ep9ce+P0Z9es+JmsvL2/rLphz+Frcw==",
 			"cpu": [
 				"x64"
 			],
@@ -750,9 +750,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-arm64-gnu": {
-			"version": "14.1.1",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.1.1.tgz",
-			"integrity": "sha512-YDQfbWyW0JMKhJf/T4eyFr4b3tceTorQ5w2n7I0mNVTFOvu6CGEzfwT3RSAQGTi/FFMTFcuspPec/7dFHuP7Eg==",
+			"version": "14.2.12",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.12.tgz",
+			"integrity": "sha512-qBy7OiXOqZrdp88QEl2H4fWalMGnSCrr1agT/AVDndlyw2YJQA89f3ttR/AkEIP9EkBXXeGl6cC72/EZT5r6rw==",
 			"cpu": [
 				"arm64"
 			],
@@ -765,9 +765,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-arm64-musl": {
-			"version": "14.1.1",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.1.1.tgz",
-			"integrity": "sha512-fiuN/OG6sNGRN/bRFxRvV5LyzLB8gaL8cbDH5o3mEiVwfcMzyE5T//ilMmaTrnA8HLMS6hoz4cHOu6Qcp9vxgQ==",
+			"version": "14.2.12",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.12.tgz",
+			"integrity": "sha512-EfD9L7o9biaQxjwP1uWXnk3vYZi64NVcKUN83hpVkKocB7ogJfyH2r7o1pPnMtir6gHZiGCeHKagJ0yrNSLNHw==",
 			"cpu": [
 				"arm64"
 			],
@@ -780,9 +780,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-x64-gnu": {
-			"version": "14.1.1",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.1.1.tgz",
-			"integrity": "sha512-rv6AAdEXoezjbdfp3ouMuVqeLjE1Bin0AuE6qxE6V9g3Giz5/R3xpocHoAi7CufRR+lnkuUjRBn05SYJ83oKNQ==",
+			"version": "14.2.12",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.12.tgz",
+			"integrity": "sha512-iQ+n2pxklJew9IpE47hE/VgjmljlHqtcD5UhZVeHICTPbLyrgPehaKf2wLRNjYH75udroBNCgrSSVSVpAbNoYw==",
 			"cpu": [
 				"x64"
 			],
@@ -795,9 +795,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-x64-musl": {
-			"version": "14.1.1",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.1.1.tgz",
-			"integrity": "sha512-YAZLGsaNeChSrpz/G7MxO3TIBLaMN8QWMr3X8bt6rCvKovwU7GqQlDu99WdvF33kI8ZahvcdbFsy4jAFzFX7og==",
+			"version": "14.2.12",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.12.tgz",
+			"integrity": "sha512-rFkUkNwcQ0ODn7cxvcVdpHlcOpYxMeyMfkJuzaT74xjAa5v4fxP4xDk5OoYmPi8QNLDs3UgZPMSBmpBuv9zKWA==",
 			"cpu": [
 				"x64"
 			],
@@ -810,9 +810,9 @@
 			}
 		},
 		"node_modules/@next/swc-win32-arm64-msvc": {
-			"version": "14.1.1",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.1.1.tgz",
-			"integrity": "sha512-1L4mUYPBMvVDMZg1inUYyPvFSduot0g73hgfD9CODgbr4xiTYe0VOMTZzaRqYJYBA9mana0x4eaAaypmWo1r5A==",
+			"version": "14.2.12",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.12.tgz",
+			"integrity": "sha512-PQFYUvwtHs/u0K85SG4sAdDXYIPXpETf9mcEjWc0R4JmjgMKSDwIU/qfZdavtP6MPNiMjuKGXHCtyhR/M5zo8g==",
 			"cpu": [
 				"arm64"
 			],
@@ -825,9 +825,9 @@
 			}
 		},
 		"node_modules/@next/swc-win32-ia32-msvc": {
-			"version": "14.1.1",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.1.1.tgz",
-			"integrity": "sha512-jvIE9tsuj9vpbbXlR5YxrghRfMuG0Qm/nZ/1KDHc+y6FpnZ/apsgh+G6t15vefU0zp3WSpTMIdXRUsNl/7RSuw==",
+			"version": "14.2.12",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.12.tgz",
+			"integrity": "sha512-FAj2hMlcbeCV546eU2tEv41dcJb4NeqFlSXU/xL/0ehXywHnNpaYajOUvn3P8wru5WyQe6cTZ8fvckj/2XN4Vw==",
 			"cpu": [
 				"ia32"
 			],
@@ -840,9 +840,9 @@
 			}
 		},
 		"node_modules/@next/swc-win32-x64-msvc": {
-			"version": "14.1.1",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.1.1.tgz",
-			"integrity": "sha512-S6K6EHDU5+1KrBDLko7/c1MNy/Ya73pIAmvKeFwsF4RmBFJSO7/7YeD4FnZ4iBdzE69PpQ4sOMU9ORKeNuxe8A==",
+			"version": "14.2.12",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.12.tgz",
+			"integrity": "sha512-yu8QvV53sBzoIVRHsxCHqeuS8jYq6Lrmdh0briivuh+Brsp6xjg80MAozUsBTAV9KNmY08KlX0KYTWz1lbPzEg==",
 			"cpu": [
 				"x64"
 			],
@@ -926,11 +926,17 @@
 				"sly": "start.js"
 			}
 		},
+		"node_modules/@swc/counter": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+			"integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ=="
+		},
 		"node_modules/@swc/helpers": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.2.tgz",
-			"integrity": "sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==",
+			"version": "0.5.5",
+			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.5.tgz",
+			"integrity": "sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==",
 			"dependencies": {
+				"@swc/counter": "^0.1.3",
 				"tslib": "^2.4.0"
 			}
 		},
@@ -4348,12 +4354,12 @@
 			"dev": true
 		},
 		"node_modules/next": {
-			"version": "14.1.1",
-			"resolved": "https://registry.npmjs.org/next/-/next-14.1.1.tgz",
-			"integrity": "sha512-McrGJqlGSHeaz2yTRPkEucxQKe5Zq7uPwyeHNmJaZNY4wx9E9QdxmTp310agFRoMuIYgQrCrT3petg13fSVOww==",
+			"version": "14.2.12",
+			"resolved": "https://registry.npmjs.org/next/-/next-14.2.12.tgz",
+			"integrity": "sha512-cDOtUSIeoOvt1skKNihdExWMTybx3exnvbFbb9ecZDIxlvIbREQzt9A5Km3Zn3PfU+IFjyYGsHS+lN9VInAGKA==",
 			"dependencies": {
-				"@next/env": "14.1.1",
-				"@swc/helpers": "0.5.2",
+				"@next/env": "14.2.12",
+				"@swc/helpers": "0.5.5",
 				"busboy": "1.6.0",
 				"caniuse-lite": "^1.0.30001579",
 				"graceful-fs": "^4.2.11",
@@ -4367,24 +4373,28 @@
 				"node": ">=18.17.0"
 			},
 			"optionalDependencies": {
-				"@next/swc-darwin-arm64": "14.1.1",
-				"@next/swc-darwin-x64": "14.1.1",
-				"@next/swc-linux-arm64-gnu": "14.1.1",
-				"@next/swc-linux-arm64-musl": "14.1.1",
-				"@next/swc-linux-x64-gnu": "14.1.1",
-				"@next/swc-linux-x64-musl": "14.1.1",
-				"@next/swc-win32-arm64-msvc": "14.1.1",
-				"@next/swc-win32-ia32-msvc": "14.1.1",
-				"@next/swc-win32-x64-msvc": "14.1.1"
+				"@next/swc-darwin-arm64": "14.2.12",
+				"@next/swc-darwin-x64": "14.2.12",
+				"@next/swc-linux-arm64-gnu": "14.2.12",
+				"@next/swc-linux-arm64-musl": "14.2.12",
+				"@next/swc-linux-x64-gnu": "14.2.12",
+				"@next/swc-linux-x64-musl": "14.2.12",
+				"@next/swc-win32-arm64-msvc": "14.2.12",
+				"@next/swc-win32-ia32-msvc": "14.2.12",
+				"@next/swc-win32-x64-msvc": "14.2.12"
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": "^1.1.0",
+				"@playwright/test": "^1.41.2",
 				"react": "^18.2.0",
 				"react-dom": "^18.2.0",
 				"sass": "^1.3.0"
 			},
 			"peerDependenciesMeta": {
 				"@opentelemetry/api": {
+					"optional": true
+				},
+				"@playwright/test": {
 					"optional": true
 				},
 				"sass": {
@@ -6356,9 +6366,9 @@
 			}
 		},
 		"node_modules/tslib": {
-			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
 		},
 		"node_modules/tsutils": {
 			"version": "3.21.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"@types/react-dom": "18.0.10",
 		"clsx": "^2.0.0",
 		"module-name": "^0.0.1-security",
-		"next": "14.1.1",
+		"next": "14.2.12",
 		"next-translate": "^1.6.0",
 		"react": "18.2.0",
 		"react-dom": "18.2.0",


### PR DESCRIPTION
(https://github.com/GalsenDev221/website/commit/934562e595d2a1dd90f104f54d2426f3fd6a7351) 

Bumps [next](https://github.com/vercel/next.js) from 14.1.1 to 14.2.12.
- [Release notes](https://github.com/vercel/next.js/releases)
- [Changelog](https://github.com/vercel/next.js/blob/canary/release.js)
- [Commits](https://github.com/vercel/next.js/compare/v14.1.1...v14.2.12)

---
updated-dependencies:
- dependency-name: next
  dependency-type: direct:production
...